### PR TITLE
Fix lightbox image cut off at bottom for tall portrait images

### DIFF
--- a/styles/lightbox.css
+++ b/styles/lightbox.css
@@ -151,10 +151,11 @@ body.lb-disable-scrolling {
 /* ─── Image container ─────────────────────────────────────────────────────── */
 
 /* Wraps the image, spinner, and nav hit areas.
-   flex-shrink:0 prevents the container from collapsing when the caption is tall. */
+   min-height:0 allows the container to shrink within the flex column so the
+   image never overflows the .lb-content max-height constraint. */
 .lb-outerContainer {
   position: relative;
-  flex-shrink: 0;
+  min-height: 0;
   border-radius: 3px;
   overflow: hidden;
   background-color: #111;
@@ -162,11 +163,13 @@ body.lb-disable-scrolling {
 
 /* The photo itself.
    width/height 100% fills the outerContainer; object-fit:contain keeps the
-   aspect ratio correct without any JS size calculations. */
+   aspect ratio correct without any JS size calculations.
+   max-height ensures tall portrait images never exceed the viewport. */
 .lb-image {
   display: block;
   width: 100%;
-  height: 100%;
+  height: auto;
+  max-height: calc(90vh - 60px); /* 90vh minus space for the caption bar */
   object-fit: contain;
   border: 4px solid white;
   border-radius: 3px;


### PR DESCRIPTION
## Summary

- Replace `flex-shrink: 0` with `min-height: 0` on `.lb-outerContainer` so the container can shrink within the flex column and respect the `max-height: 90vh` constraint on `.lb-content`
- Change `.lb-image` from `height: 100%` to `height: auto` and add `max-height: calc(90vh - 60px)` to prevent tall portrait images from overflowing the visible viewport area

## Problem

In the gallery lightbox, portrait-oriented images were being cut off at the bottom because `.lb-outerContainer` had `flex-shrink: 0`, preventing it from shrinking to fit within the parent's height constraint.